### PR TITLE
Fix quadprog wrapper for 1-dim A matrix

### DIFF
--- a/qpsolvers/quadprog_.py
+++ b/qpsolvers/quadprog_.py
@@ -69,7 +69,7 @@ def quadprog_solve_qp(P, q, G=None, h=None, A=None, b=None, initvals=None):
     if A is not None:
         qp_C = -vstack([A, G]).T
         qp_b = -hstack([b, h])
-        meq = A.shape[0]
+        meq = A.shape[0] if A.ndim > 1 else 1
     else:  # no equality constraint
         qp_C = -G.T
         qp_b = -h


### PR DESCRIPTION
If A is a 1-dim array, e.g. created with `numpy.array([1., 2.])`, the result of `quadprog_solve_qp` is wrong because the `meq` is calculated incorrectly as `meq = A.shape[0]`. I suggest using something like `A.shape[0] if A.ndim > 1 else 1` instead.