### PR TITLE
[minor] Update a link to qpOASES

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The list of supported solvers currently includes:
 
 - Dense solvers:
     - [CVXOPT](http://cvxopt.org/)
-    - [qpOASES](https://projects.coin-or.org/qpOASES)
+    - [qpOASES](https://github.com/coin-or/qpOASES)
     - [quadprog](https://pypi.python.org/pypi/quadprog/)
 - Sparse solvers:
     - [ECOS](https://web.stanford.edu/~boyd/papers/ecos.html)


### PR DESCRIPTION
The site on <https://projects.coin-or.org/qpOASES> says "This project has moved to <​https://github.com/coin-or/qpOASES>", so I updated the URL.