### PR TITLE
Fix for searching in error object rather than message string

### DIFF
--- a/qpsolvers/quadprog_.py
+++ b/qpsolvers/quadprog_.py
@@ -87,7 +87,7 @@ def quadprog_solve_qp(P, q, G=None, h=None, A=None, b=None, initvals=None,
     try:
         return solve_qp(qp_G, qp_a, qp_C, qp_b, meq)[0]
     except ValueError as e:
-        if "matrix G is not positive definite" in e:
+        if "matrix G is not positive definite" in str(e):
             # quadprog writes G the cost matrix that we write P in this package
             raise ValueError("matrix P is not positive definite")
         raise


### PR DESCRIPTION
# Description
-  As reported in this issue https://github.com/stephane-caron/qpsolvers/issues/25 
- When a value error occurs (for example a mix of value types) then an error is raised within raising the value error because it is searching for a string in an object rather than in the error message itself.