### PR TITLE
[cvxpy] fix deprecation warning

### DIFF
--- a/qpsolvers/cvxpy_.py
+++ b/qpsolvers/cvxpy_.py
@@ -71,12 +71,12 @@ def cvxpy_solve_qp(P, q, G=None, h=None, A=None, b=None, initvals=None,
     n = q.shape[0]
     x = Variable(n)
     P = Constant(P)  # see http://www.cvxpy.org/en/latest/faq/
-    objective = Minimize(0.5 * quad_form(x, P) + q * x)
+    objective = Minimize(0.5 * quad_form(x, P) + q @ x)
     constraints = []
     if G is not None:
-        constraints.append(G * x <= h)
+        constraints.append(G @ x <= h)
     if A is not None:
-        constraints.append(A * x == b)
+        constraints.append(A @ x == b)
     prob = Problem(objective, constraints)
     prob.solve(solver=solver, verbose=verbose)
     x_opt = array(x.value).reshape((n,))


### PR DESCRIPTION
The deprecation warning was the following:
```
This use of ``*`` has resulted in matrix multiplication.
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.
```