### PR TITLE
fix cvxpy deprecation warning

### DIFF
--- a/qpsolvers/cvxpy_.py
+++ b/qpsolvers/cvxpy_.py
@@ -71,12 +71,12 @@ def cvxpy_solve_qp(P, q, G=None, h=None, A=None, b=None, initvals=None,
     n = q.shape[0]
     x = Variable(n)
     P = Constant(P)  # see http://www.cvxpy.org/en/latest/faq/
-    objective = Minimize(0.5 * quad_form(x, P) + q * x)
+    objective = Minimize(0.5 * quad_form(x, P) + q @ x)
     constraints = []
     if G is not None:
-        constraints.append(G * x <= h)
+        constraints.append(G @ x <= h)
     if A is not None:
-        constraints.append(A * x == b)
+        constraints.append(A @ x == b)
     prob = Problem(objective, constraints)
     prob.solve(solver=solver, verbose=verbose)
     x_opt = array(x.value).reshape((n,))


### PR DESCRIPTION
The newest version spits out a warning for every problem you solve, like this 

~~~bash
  warnings.warn(__STAR_MATMUL_WARNING__, UserWarning)
/home/samuel/anaconda3/envs/py37/lib/python3.7/site-packages/cvxpy/expressions/expression.py:550: UserWarning: 
This use of ``*`` has resulted in matrix multiplication.
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.

  warnings.warn(__STAR_MATMUL_WARNING__, UserWarning)
/home/samuel/anaconda3/envs/py37/lib/python3.7/site-packages/cvxpy/expressions/expression.py:550: UserWarning: 
This use of ``*`` has resulted in matrix multiplication.
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.

  warnings.warn(__STAR_MATMUL_WARNING__, UserWarning)
/home/samuel/anaconda3/envs/py37/lib/python3.7/site-packages/cvxpy/expressions/expression.py:550: UserWarning: 
This use of ``*`` has resulted in matrix multiplication.
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.
~~~

This fixes it by using @ for the matrix matrix and matrix vector multiplies (which is hopefully the correct operation to do here without breaking older versions)