### PR TITLE
Fixing quadprog_solve_qp behavior with infeasible problems

### DIFF
--- a/qpsolvers/quadprog_.py
+++ b/qpsolvers/quadprog_.py
@@ -90,4 +90,4 @@ def quadprog_solve_qp(P, q, G=None, h=None, A=None, b=None, initvals=None,
         if "matrix G is not positive definite" in str(e):
             # quadprog writes G the cost matrix that we write P in this package
             raise ValueError("matrix P is not positive definite")
-        raise
+        return None


### PR DESCRIPTION
quadprog_solve_qp raises a value error if you give an infeasible problem. This is not what the docs say the behavior is. The behavior should be returns ```None``` if we have an infeasible problem.