### PR TITLE
Adding additional solver output

### DIFF
--- a/qpsolvers/solver_output.py
+++ b/qpsolvers/solver_output.py
@@ -29,7 +29,7 @@ import numpy
 
 
 @dataclass
-class QPOutput:
+class SolverOutput:
     """
     This is the generic Solver output object. This is the general extra infor return object for solvers. It contains\\
     all of the information you would need for the optimization solution including, optimal value, optimal solution, the \\

--- a/qpsolvers/solver_output.py
+++ b/qpsolvers/solver_output.py
@@ -10,7 +10,8 @@ class QPOutput:
     This is the generic Solver output object. This is the general extra infor return object for solvers. It contains\\
     all of the information you would need for the optimization solution including, optimal value, optimal solution, the \\
     active set, the value of the slack variables and the largange multipliers associated with every constraint.
-    Members:
+    Parameters
+    ----------
     obj: optimal objective \n
     sol: x*, numpy array \n
     Optional Parameters -> None or numpy.ndarray type

--- a/qpsolvers/solver_output.py
+++ b/qpsolvers/solver_output.py
@@ -1,3 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016-2022 The qpsolvers contributors.
+#
+# This file is part of qpsolvers.
+#
+# qpsolvers is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# qpsolvers is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with qpsolvers. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Type for extended QP solver outputs going beyond the primal solution.
+"""
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/qpsolvers/solver_output.py
+++ b/qpsolvers/solver_output.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy
+
+
+@dataclass
+class QPOutput:
+    """
+    This is the generic Solver output object. This is the general extra infor return object for solvers. It contains\\
+    all of the information you would need for the optimization solution including, optimal value, optimal solution, the \\
+    active set, the value of the slack variables and the largange multipliers associated with every constraint.
+    Members:
+    obj: optimal objective \n
+    sol: x*, numpy array \n
+    Optional Parameters -> None or numpy.ndarray type
+    slack: the slacks associated with every constraint \n
+    equality_indices: the active set of the solution, including strongly and weakly active constraints \n
+    dual: the lagrange multipliers associated with the problem\n
+    """
+    obj: float
+    sol: numpy.ndarray
+
+    slack: Optional[numpy.ndarray]
+    active_set: Optional[numpy.ndarray]
+    dual: Optional[numpy.ndarray]
+
+    def __eq__(self, other):
+        if not isinstance(other, QPOutput):
+            return NotImplemented
+
+        return numpy.allclose(self.slack, other.slack) and numpy.allclose(self.active_set,
+                                                                          other.active_set) and numpy.allclose(
+            self.dual, other.dual) and numpy.allclose(self.sol, other.sol) and numpy.allclose(self.obj, other.obj)

--- a/tests/test_check_problem_constraints.py
+++ b/tests/test_check_problem_constraints.py
@@ -21,7 +21,7 @@
 import unittest
 
 from numpy import array
-from qpsolvers.check_problem_constraints import check_problem_constraints
+from ..qpsolvers.check_problem_constraints import check_problem_constraints
 
 
 class TestCheckProblemConstraints(unittest.TestCase):

--- a/tests/test_concatenate_bounds.py
+++ b/tests/test_concatenate_bounds.py
@@ -21,7 +21,7 @@
 import unittest
 
 from numpy import allclose, array, eye
-from qpsolvers.concatenate_bounds import concatenate_bounds
+from ..qpsolvers.concatenate_bounds import concatenate_bounds
 
 
 class TestConcatenateBounds(unittest.TestCase):

--- a/tests/test_cvxopt.py
+++ b/tests/test_cvxopt.py
@@ -34,7 +34,7 @@ from qpsolvers import solve_qp
 
 try:
     import cvxopt
-    from qpsolvers.solvers.cvxopt_ import cvxopt_matrix
+    from ..qpsolvers.solvers.cvxopt_ import cvxopt_matrix
 
     class TestCVXOPT(unittest.TestCase):
 

--- a/tests/test_quadprog.py
+++ b/tests/test_quadprog.py
@@ -22,7 +22,7 @@ import unittest
 import warnings
 
 from numpy import array, dot, eye
-from qpsolvers import solve_qp
+from ..qpsolvers import solve_qp
 
 
 class TestQuadprog(unittest.TestCase):

--- a/tests/test_solve_ls.py
+++ b/tests/test_solve_ls.py
@@ -27,7 +27,7 @@ import warnings
 
 from numpy import allclose, array, dot
 from numpy.linalg import norm
-from qpsolvers import available_solvers, solve_ls
+from ..qpsolvers import available_solvers, solve_ls
 
 
 class TestSolveLS(unittest.TestCase):

--- a/tests/test_solve_qp.py
+++ b/tests/test_solve_qp.py
@@ -31,9 +31,9 @@ from numpy import allclose, array, dot, ones, random
 from numpy.linalg import norm
 from scipy.sparse import csc_matrix
 
-from qpsolvers import available_solvers, sparse_solvers
-from qpsolvers import solve_qp, solve_safer_qp
-from qpsolvers.exceptions import SolverNotFound
+from ..qpsolvers import available_solvers, sparse_solvers
+from ..qpsolvers import solve_qp, solve_safer_qp
+from ..qpsolvers.exceptions import SolverNotFound
 
 
 class TestSolveQP(unittest.TestCase):

--- a/tests/test_unfeasible_problem.py
+++ b/tests/test_unfeasible_problem.py
@@ -22,8 +22,8 @@ import unittest
 import warnings
 
 from numpy import array, dot
-from qpsolvers import available_solvers, dense_solvers
-from qpsolvers import solve_qp, solve_safer_qp
+from ..qpsolvers import available_solvers, dense_solvers
+from ..qpsolvers import solve_qp, solve_safer_qp
 
 
 class UnfeasibleProblem(unittest.TestCase):


### PR DESCRIPTION
This pr adds additional outputs such as objective function value, slacks, active set, and dual variables relating to issue #54.

So far, I have prospectively added the solver output object. I also modified the tests to run them locally; this can be removed at some point. 

@stephane-caron does this output structure look right (in solver_output.py), or do you have a different view/fields to include or exclude?